### PR TITLE
tweak style of headings of style_soundwriting.css

### DIFF
--- a/style_soundwriting.css
+++ b/style_soundwriting.css
@@ -55,18 +55,43 @@
 .pretext-content section.chapter h2.heading {
   color: var(--chaptertitle);
 }
+
+.pretext-content section.chapter h2.heading .title {
+  display:block;
+  font-size:larger;
+  margin-top: 5pt;
+}
+
 .pretext-content section.section h2.heading {
   color: var(--sectiontitle);
   border-top: 1pt solid;
   border-bottom: 1pt solid;
-  margin-bottom: 10pt;
+  margin-bottom: 20pt;
+  width: 100%;
 }
 .pretext-content section.subsection h2.heading {
   color: var(--subsectiontitle);
   border-bottom: 1pt solid;
-  margin-bottom: 5pt;
+  margin-bottom: 20pt;
+  width: 90%;
 }
 
+/* frontmatter headings: */
+.pretext-content section.frontmatter h2.heading {
+  color: var(--chaptertitle);
+  font-size:2em;
+}
+
+.pretext-content section.preface h2.heading {
+  color: var(--chaptertitle);
+  margin-bottom: 15pt;
+  font-size: 1.75em;
+}
+
+.pretext-content section.preface h2.heading .title {
+  display:block;
+  font-size:larger;
+}
 
 /* Blocks: */
 


### PR DESCRIPTION
Implemented the following:
1. Made chapter headings more distinctive (and in two lines, to match pdf)
2. Colored and styled frontmatter titles to match.
3. Extended rules on section and subsection headings, and added bottom margin