### PR TITLE
push permalink targets down so the sticky navbar does not cover them

### DIFF
--- a/pretext_add_on.css
+++ b/pretext_add_on.css
@@ -1157,6 +1157,17 @@ https://yoshiwarabooks.org/mfg/MathModels.html */
     padding-left: 0.5em;
     padding-right: 0.5em;
 }
+/* when jumping to a permalink, push down so sticky navbar does not cover */
+:target::before {
+  content: "";
+  display: block;
+  height: 42px;
+  margin: -42px 0 0;
+  border: 0;
+}
+:target > div.autopermalink {
+  top: 45px;
+}
 
 /*
 .pretext-content .autopermalink {


### PR DESCRIPTION
This uses the `:target` selector to identify when something like https://pretextbook.org/examples/sample-article/html/section-7.html#p-203 has just been jumped to. It adds a before pseudo-element to the element with the `id` and styles it to push the target down just enough to go below the navbar.

For the most part, it seems to work. Tested in Firefox, Chrome, and Safari. These pages (and only these) have the same thing in the file head:
http://spot.pcc.edu/~ajordan/temp/interesting-corollary.html
http://spot.pcc.edu/~ajordan/temp/section-7.html

Two nuts I can't crack:  
* In the first page above,  going to http://spot.pcc.edu/~ajordan/temp/interesting-corollary.html#dEf, the permalink icon gets pushed down.
* Go to a target with "Greg's L" or something similar, and this extends the "L" higher by the same amount as the pushdown. http://spot.pcc.edu/~ajordan/temp/interesting-corollary.html#ghI
