### PR TITLE
Improvements to style_oscarlevin and new proposed color management for style files

### DIFF
--- a/colors_blue_green.css
+++ b/colors_blue_green.css
@@ -38,8 +38,8 @@
 
 :root {
   --documenttitle: #2a5ea4;
-  --bodytitle: #2B5F82; 
-  --bodysubtitle: #A62E1C;
+  --bodytitle: #2b5f82; 
+  --bodysubtitle: #a62e1c;
   --bodytitlehighlight: #e0e9ff;  /* light, and contrasting to bodytitle  */
   --bodysubtitlehighlight: #fce5e4;  /* light, and contrasting to bodysubtitle  */
      /*
@@ -68,5 +68,38 @@
 
   --knowlborder: var(--bodytitlehighlight);
   --knowlbackground: var(--assemblagebackground);
+
+  /* Colors for block envirornments: */
+  /* 
+  We specify 4 color families (hues), each with 5 hue/lightness options, to be used by style files if they wish.  
+  Primary and secondary are taken from the TOC color theme.
+  Info is targeted to non-core content (asides, technology tips, etc)
+  Alert is a jaring highling color (for warnings, cautions, etc).
+  Each color has *light, *dark variants (adjusting the lightness of hsl) and *rich, *dull variants (adjusting the saturation).
+  The *dark, if specified, should always contrast correctly with white text (we could later specify a *dark-text to be the correct contrast with *dark).
+  */
+  --primary: hsl(246, 60%, 60%);  /* #1100aa */
+  --primarylight: hsl(246, 60%, 90%);  /* #1100aa */
+  --primarydark: hsl(246, 60%, 20%);  /* #1100aa */
+  --primaryrich: hsl(246, 100%, 60%);  /* #1100aa */
+  --primarydull: hsl(246, 10%, 60%);  /* #1100aa */
+
+  --secondary: hsl(136, 52%, 60%); /* chaptertoc */
+  --secondarylight: hsl(136, 52%, 90%); /* same hue as chaptertoc */
+  --secondarydark: hsl(136, 52%, 15%); /* chaptertoc */
+  --secondaryrich: hsl(136, 100%, 50%); /* chaptertoc */
+  --secondarydull: hsl(136, 10%, 50%); /* chaptertoc */
+
+  --info: hsl(204, 86%, 60%);	
+  --infolight: hsl(204, 86%, 90%);	
+  --infodark: hsl(204, 86%, 20%);	
+  --inforich: hsl(204, 100%, 50%);	
+  --infodull: hsl(204, 15%, 60%);	
+
+  --alert: hsl(8, 60%, 38%);
+  --alertlight: hsl(8, 60%, 85%);
+  --alertdark: hsl(8, 60%, 20%);
+  --alertrich: hsl(8, 100%, 50%);
+  --alertdull: hsl(8, 15%, 60%);
 }
 

--- a/colors_blue_green.css
+++ b/colors_blue_green.css
@@ -71,35 +71,48 @@
 
   /* Colors for block envirornments: */
   /* 
-  We specify 4 color families (hues), each with 5 hue/lightness options, to be used by style files if they wish.  
-  Primary and secondary are taken from the TOC color theme.
-  Info is targeted to non-core content (asides, technology tips, etc)
-  Alert is a jaring highling color (for warnings, cautions, etc).
-  Each color has *light, *dark variants (adjusting the lightness of hsl) and *rich, *dull variants (adjusting the saturation).
-  The *dark, if specified, should always contrast correctly with white text (we could later specify a *dark-text to be the correct contrast with *dark).
+  We specify 6 color families (hues), each with 5 hue/lightness options, to be used by style files if they wish. 
+
+  The hues should roughly corrspond to red, orange, yellow, green, blue, violet, but should be consistent with the colors specified for titles and toc defined above. 
+  
+  Each color has *light, *dark variants (adjusting the lightness of hsl) and *rich, *dull variants (adjusting the saturation). *light and *dull should work for a main background. The standard and *riche should work for borders. For a bold title background, the *dark could be used.
+
+  The *dark should always contrast correctly with white text (we could later specify a *dark-text to be the correct contrast with *dark). All other variants should contrast correctly with black text.
   */
-  --primary: hsl(246, 60%, 60%);  /* #1100aa */
-  --primarylight: hsl(246, 60%, 90%);  /* #1100aa */
-  --primarydark: hsl(246, 60%, 20%);  /* #1100aa */
-  --primaryrich: hsl(246, 100%, 60%);  /* #1100aa */
-  --primarydull: hsl(246, 10%, 60%);  /* #1100aa */
+  --red: hsl(345, 60%, 60%);  
+  --redlight: hsl(345, 60%, 80%);  
+  --reddark: hsl(345, 60%, 15%);  
+  --redrich: hsl(345, 100%, 60%);  
+  --reddull: hsl(345, 20%, 60%);  
 
-  --secondary: hsl(136, 52%, 60%); /* chaptertoc */
-  --secondarylight: hsl(136, 52%, 90%); /* same hue as chaptertoc */
-  --secondarydark: hsl(136, 52%, 15%); /* chaptertoc */
-  --secondaryrich: hsl(136, 100%, 50%); /* chaptertoc */
-  --secondarydull: hsl(136, 10%, 50%); /* chaptertoc */
+  --orange: hsl(30, 70%, 60%);  
+  --orangelight: hsl(30, 60%, 80%);  
+  --orangedark: hsl(30, 60%, 15%);  
+  --orangerich: hsl(30, 100%, 60%);  
+  --orangedull: hsl(30, 30%, 60%);  
 
-  --info: hsl(204, 86%, 60%);	
-  --infolight: hsl(204, 86%, 90%);	
-  --infodark: hsl(204, 86%, 20%);	
-  --inforich: hsl(204, 100%, 50%);	
-  --infodull: hsl(204, 15%, 60%);	
+  --yellow: hsl(58, 60%, 60%);  
+  --yellowlight: hsl(58, 60%, 80%);  
+  --yellowdark: hsl(58, 60%, 15%);  
+  --yellowrich: hsl(58, 100%, 60%);  
+  --yellowdull: hsl(58, 30%, 60%);  
+  
+  --green: hsl(136, 52%, 33%);
+  --greenlight: hsl(136, 52%, 80%);  
+  --greendark: hsl(136, 52%, 15%);  
+  --greenrich: hsl(136, 100%, 60%);  
+  --greendull: hsl(136, 20%, 60%);
+    
+  --blue: hsl(214, 59%, 60%);
+  --bluelight: hsl(214, 59%, 80%);  
+  --bluedark: hsl(214, 59%, 15%);  
+  --bluerich: hsl(214, 100%, 50%);  
+  --bluedull: hsl(214, 20%, 50%);
 
-  --alert: hsl(8, 60%, 38%);
-  --alertlight: hsl(8, 60%, 85%);
-  --alertdark: hsl(8, 60%, 20%);
-  --alertrich: hsl(8, 100%, 50%);
-  --alertdull: hsl(8, 15%, 60%);
+  --violet: hsl(259, 60%, 60%);  
+  --violetlight: hsl(259, 60%, 80%);  
+  --violetdark: hsl(259, 60%, 15%);  
+  --violetrich: hsl(259, 100%, 60%);  
+  --violetdull: hsl(259, 20%, 60%);  
 }
 

--- a/style_oscarlevin.css
+++ b/style_oscarlevin.css
@@ -1,113 +1,88 @@
 
-/*
 :root {
-  --documenttitle: #395E66;
-  --bodytitle: #A62E1C;
-  --bodysubtitle: #2B5F82;
-  --bodytitlehighlight: #e0e9ff;
-  --bodysubtitlehighlight: #FCE5E4;
-
-  --chaptertoc: #395E66;
-  --chaptertoctext: white;
-  --chaptertocactive: #00A092;
-  --chaptertoctextactive: white;
-  --sectiontoc: #f0f0f0;
-  --sectiontoctext: #395E66;
-  --sectiontocactive: var(--chaptertocactive);
-  --sectiontoctextactive: var(--chaptertoctextactive);
-  --tocborder: #1f4283;
-
-  --highlighttoc: #223843;
-  --highlighttoctext: white;
-  --highlighttocborder: white;
-
-  --assembborder: #bfd5ec;
-  --assembbackground: #e9eff5;
-
-  --knowlborder: #e0e9ff;
-  --knowlbackground: #f5f8ff;
-
-}
-*/
-
-
-:root {
-/* Set colors for blocks */
+/* Set colors for environments */
   
-  --assembbackground: var(--infolight, hsl(210, 40%, 94%));
-  --assembborder: var(--info, hsl(210, 40%, 75%));
-  --assembheading: var(--infodark, hsl(210, 40%, 25%));
-  --definitionbackground: var(--secondarylight, hsl(180, 40%, 94%));
-  --definitionborder: var(--secondarydull, hsl(180, 40%, 75%));
-  --definitiondarkborder: var(--secondaryrich, hsl(180, 40%, 25%));
-  --theorembackground: var(--primarylight, hsl(270, 40%, 94%));
-  --theoremborder: var(--primary, hsl(270, 40%, 75%));
-  --theoremdarkborder: var(--primarydark, hsl(270, 40%, 25%));
-  --examplebackground: var(--primarylight, hsl(240, 40%, 94%));
-  --example: var(--primary, hsl(240, 40%, 75%));
-  --exampledark: var(--primarydark, hsl(240, 40%, 25%));
-  --projectbackground: var(--primarylight, hsl(180, 40%, 94%));
-  --projectborder: var(--primary, hsl(180, 40%, 75%));
-  --investigateborder: var(--primaryrich, hsl(180, 40%, 25%));
+  --assembbody: var(--bluelight, hsl(210, 90%, 80%));
+  --assembborder: var(--blue, hsl(210, 40%, 60%));
+  --assembhead: var(--blue, hsl(210, 40%, 60%));
+  --definitionbody: var(--greenlight, hsl(180, 40%, 80%));
+  --definitionborder: var(--green, hsl(180, 40%, 50%));
+  --definitionhead: var(--green, hsl(180, 40%, 50%));
+  --theorembody: var(--violetlight, hsl(270, 40%, 94%));
+  --theoremborder: var(--violet, hsl(270, 40%, 75%));
+  --theoremhead: var(--violetdark, hsl(270, 40%, 25%));
+  --examplebody: var(--bluedull, hsl(240, 40%, 90%));
+  --exampleborder: var(--bluedark, hsl(240, 40%, 25%));
+  --examplehead: var(--exampleborder);
+  --examplelikebody: var(--examplebody);
+  --examplelikeborder: var(--bluedull, hsl(240, 40%, 75%));
+  --examplelikehead: var(--examplelikeborder);
+  --projectbody: var(--greenlight, hsl(180, 40%, 94%));
+  --projectborder: var(--green, hsl(180, 40%, 75%));
+  --projecthead: var(--green, hsl(180, 40%, 75%));
+  --investigateborder: var(--bluerich, hsl(180, 40%, 25%));
+  --goalborder: var(--violetrich, hsl(270, 90%, 25%));
+  --remarklikebody: var(--yellowlight, hsl(59, 55%, 85%));
+  --remarklikeborder: var(--yellow, hsl(59, 55%, 50%));
+  --remarklikehead: var(--yellow, hsl(59, 55%, 50%));
+  --computationborder: var(--orangedull, hsl(180, 40%, 75%));
 
-  /* --knowlborder: var(--bodytitlehighlight);
-  --knowlborder: white;
-  --knowlbackground: var(--assembbackground);
-  --knowlbackground: white; */
+  /* temporary workaround for setcolors.css use of assemblage */
+  --asemblagebackground: var(--assembbody) !important;
+  --assemblageborder: var(--assembborder) !important;
 }
 
-/* Remove Greg-L on assemblage and everything else */
-/*
-.pretext-content article.theorem-like::after, .pretext-content article.definition-like::after, .pretext-content article.example-like::after, .pretext-content article.project-like::after, .pretext-content article.objectives::after, .pretext-content article.outcomes::after, .pretext-content article.remark-like::after {
-  border-bottom: none;
-}
+/* We can style all the *-like environments: 
+    definition-like, 
+    theorem-like, 
+    example-like, 
+    project-like, 
+    remark-like, 
+    computation-like, 
+    goal-like, and
+    assemblage-like. 
+  We also could do something for proofs, and commentary. 
+
+  (should we style aside-like?  Or just copy from style_default?)
+  
+  We define the style of environments in three steps: first the shape, then the color, and finally the shape and color of the heading/title.  The only reason to group these as such is that we can then have a common shape for differet *-like elements, but still allow for different colors to distinguish them.
+
+  Start with the important custom environments (theorem might be different from the other theorem-like, etc.), then clean up any standard *-like.
+  
 */
 
+/* definitions, theorems, assemblages, with theorem-like.theorem distinguished */
 .pretext-content .assemblage-like,
 .pretext-content .definition-like,
-.pretext-content .theorem-like {
-    margin-top: 1.25em;
+.pretext-content .theorem-like.theorem {
+    margin-top: 1.75em;
     padding: 1em;
-    border-radius: 3px;
+    border-radius: 2px;
     margin-bottom: 1em;
 }
 
-/* backgrounds and borders: */
+.pretext-content .theorem-like {
+  margin-top: 1.25em;
+  padding: 1em;
+  border-radius: 2px;
+  margin-bottom: 1em;
+}
+
 .pretext-content .assemblage-like{
-    background-color: var(--assembbackground);
+    background-color: var(--assembbody);
     border: 2px solid var(--assembborder);
 }
 
-.pretext-content .theorem-like {
-  background-color: var(--theorembackground);
-/*  border-left: 2px solid var(--theoremborder);
-*/
-  border: 2px solid var(--theoremborder);
-
+.pretext-content .definition-like {
+  background-color: var(--definitionbody);
+  border: 2px solid var(--definitionborder);
 }
 
 .pretext-content .theorem-like.theorem,
-.pretext-content .theorem-like.principle {
-    background-color: var(--theorembackground);
-    border: 2px solid var(--theoremborder);
+.pretext-content .theorem-like {
+  background-color: var(--theorembody);
+  border: 2px solid var(--theoremborder);
 }
-
-.pretext-content .definition-like {
-    background-color: var(--definitionbackground);
-    border: 2px solid var(--definitionborder);
-}
-
-/* .pretext-content .example-like {
-    background-color: var(--examplebackground);
-    border: 2px solid var(--exampleborder);
-} */
-
-/* .pretext-content .theorem-like.proposition,
-.pretext-content .theorem-like.lemma,
-.pretext-content .theorem-like.corollary {
-    background-color: var(--theorembackground);
-    border-left: 2px solid var(--theoremborder);
-} */
 
 .pretext-content .assemblage-like .heading,
 .pretext-content .definition-like .heading,
@@ -119,7 +94,7 @@
 }
 
 .pretext-content .assemblage-like .heading {
-  background-color: var(--assembborder);
+  background-color: var(--assembhead);
   color: #000;
 }
 
@@ -132,34 +107,94 @@
   background-color: var(--theoremborder);
   color: #000;
 }
-/* .pretext-content .theorem-like.corollary .heading {
-    background-color: var(--bodysubtitlehighlight);
-    border: 2px solid var(--bodysubtitle);
-}
-.pretext-content .theorem-like.principle .heading {
-    background-color: var(--assembborder);
-} */
 
-.pretext-content .assemblage-like .heading::after,
-.pretext-content .theorem-like.theorem .heading::after,
-.pretext-content .theorem-like.principle .heading::after {
-    content: "";
-}
+
 .pretext-content .assemblage-like .heading + p,
 .pretext-content .theorem-like.theorem .heading + p,
 .pretext-content .definition-like .heading + p {
-    display: block;
+  display: block;
+  margin-top: .5em;
 }
 
-/* These gradients need to be adjusted to match background colors */
-.pretext-content .assemblage-like .MJXc-display,
-.pretext-content .definition-like .MJXc-display,
-.pretext-content .theorem-like.theorem .MJXc-display {
-    background-image: linear-gradient(to right, #e9eff5, #e9eff5), linear-gradient(to right, #e9eff5, #e9eff5), linear-gradient(to right, rgba(0,0,0,.25), rgba(242,242,254,0)), linear-gradient(to left, rgba(0,0,0,.25), rgba(242,242,254,0));
+/* Examples and example-like; computation-like styled same as example-like with different colors */
+.pretext-content .example-like,
+.pretext-content .computation-like {
+  padding-left: 0.8em;
+  padding-bottom: 0.5em;
 }
-.pretext-content .theorem-like.corollary .MJXc-display {
-    background-image: linear-gradient(to right, var(--bodytitlehighlight), var(--bodytitlehighlight)), linear-gradient(to right, var(--bodytitlehighlight), var(--bodytitlehighlight)), linear-gradient(to right, rgba(0,0,0,.25), rgba(242,242,254,0)), linear-gradient(to left, rgba(0,0,0,.25), rgba(242,242,254,0));
+
+.pretext-content .example-like.example {
+  border-left: 0.1em solid var(--examplehead);
+  border-bottom: 0.1em solid var(--examplehead);
 }
+
+.pretext-content .example-like {
+  border-left: 0.1em solid var(--examplelikeborder);
+  border-bottom: 0.1em solid var(--examplelikeborder);
+}
+
+.pretext-content .computation-like {
+  border-left: 0.1em solid var(--computationborder);
+  border-bottom: 0.1em solid var(--computationborder);
+}
+
+.pretext-content .example-like > .heading,
+.pretext-content .computation-like > .heading {
+  display: inline-block;
+  padding: 0.3em 0.5em;
+  margin-left: -0.8em;
+}
+
+
+.pretext-content .example-like.example > .heading {
+  border: 0.1em solid var(--examplehead);   /* maybe no border-left? */
+  background: var(--examplehead);
+  color: white;
+}
+
+.pretext-content .example-like > .heading {
+  background: var(--examplelikeborder);
+  color: black;
+}
+
+.pretext-content .computation-like > .heading {
+  background: var(--computationborder);
+  color: black;
+}
+
+.pretext-content .example-like > .heading + p,
+.pretext-content .computation-like > .heading + p,
+.pretext-content .example-like > .heading + .introduction, 
+.pretext-content .computation-like > .heading + .introduction {
+  display: block;
+  padding-top: 0.3em;
+}
+
+/* Project-like */
+.pretext-content .project-like {
+  background-color: white;
+  border: solid 3px var(--projectborder);
+  border-radius: 10px;
+  padding: 10px;
+  margin-bottom: 1em;
+}
+
+.pretext-content .project-like.investigation {
+  border-color: var(--investigateborder);
+}
+
+.pretext-content .project-like > .heading {
+  margin-top: -1.5em;
+  background-color: white;
+  display: table !important;
+  padding: 5px 1em;
+  margin-left: 10px;
+  font-style: italic;
+  font-size: 120% !important;
+}
+
+
+/* Goal-like */
 
 .pretext-content .goal-like {
   background-color: white;
@@ -168,12 +203,12 @@
   margin-bottom: 1em;
 }
 .pretext-content .goal-like.objectives {
-  border-top: solid 3px var(--bodysubtitle);
-  border-bottom: solid 3px var(--bodysubtitle);
+  border-top: solid 3px var(--goalborder);
+  border-bottom: solid 3px var(--goalborder);
 }
 .pretext-content .goal-like.outcomes {
-  border-top: solid 3px var(--bodytitle);
-  border-bottom: solid 3px var(--bodytitle);
+  border-top: solid 3px var(--goalborder);
+  border-bottom: solid 3px var(--goalborder);
 }
 
 .pretext-content .goal-like .heading {
@@ -186,132 +221,238 @@
   font-size: 120%;
 }
 
-/* .pretext-content .goal-like .codenumber {
-  display:none;
+/* remark-like */
+
+.pretext-content .remark-like {
+  margin-top: 1.25em;
+  padding: 1em;
+  margin-bottom: 1em;
+  border-radius: 0px;
+  border-left: 5px solid var(--remarklikeborder);
+  background-color: var(--remarklikebody);
 }
 
-.pretext-content .goal-like .heading::after {
-  display:none;
-} */
 
+/* proofs */
 
-.pretext-content section article.project-like {
-  background-color: white;
-  border: solid 3px var(--projectborder);
-  border-radius: 10px;
-  padding: 10px;
+.pretext-content section > .proof {
   margin-bottom: 1em;
 }
 
-.pretext-content section article.project-like.investigation {
-  border-color: var(--investigateborder);
+
+/* Common fixes? */
+.pretext-content .assemblage-like .heading::after,
+.pretext-content .theorem-like.theorem .heading::after,
+.pretext-content .theorem-like .heading::after,
+.pretext-content .example-like > .heading::after,
+.pretext-content .project-like > .heading::after {
+  content: "";
 }
 
-.pretext-content section article.project-like > .heading {
-  margin-top: -1.5em;
-  background-color: white;
-  display: table !important;
-  padding: 5px 1em;
-  margin-left: 10px;
-  font-style: italic;
-  font-size: 120% !important;
+/* Fixes for mathjax: */
+/* These gradients need to be adjusted to match background colors */
+.pretext-content .assemblage-like .MJXc-display,
+.pretext-content .definition-like .MJXc-display,
+.pretext-content .theorem-like.theorem .MJXc-display {
+    background-image: linear-gradient(to right, #e9eff5, #e9eff5), linear-gradient(to right, #e9eff5, #e9eff5), linear-gradient(to right, rgba(0,0,0,.25), rgba(242,242,254,0)), linear-gradient(to left, rgba(0,0,0,.25), rgba(242,242,254,0));
+}
+.pretext-content .theorem-like.corollary .MJXc-display {
+    background-image: linear-gradient(to right, var(--bodytitlehighlight), var(--bodytitlehighlight)), linear-gradient(to right, var(--bodytitlehighlight), var(--bodytitlehighlight)), linear-gradient(to right, rgba(0,0,0,.25), rgba(242,242,254,0)), linear-gradient(to left, rgba(0,0,0,.25), rgba(242,242,254,0));
 }
 
-.pretext-content section article.example-like {
-    padding-left: 0.8em;
-    padding-bottom: 0.5em;
-}
+/* 
+END OF STYLE_OSCARLEVIN
+(below is only stuff copied from style_default)
+*/
 
-.pretext-content section article.example-like {
-    border-left: 0.1em solid var(--exampleborder);
-    border-bottom: 0.1em solid var(--exampleborder);
-}
-.pretext-content section article.example-like.example {
-    border-left: 0.1em solid var(--exampledarkborder);
-    border-bottom: 0.1em solid var(--exampledarkborder);
-}
-.pretext-content section article article.example-like,
-.pretext-content section article article.example-like.example {
+
+
+/* Assides, copied directly from style_default.css */
+/* next selector first part of the following is due to the mistake of
+   putting paragraph spacing in the margin-bottom 
+   Redo when we fix that error */
+.pretext-content .aside-like {
+ /*   margin-top: -1.25em;
+*/
+    position: absolute;
+    margin-left: 45%;
+    z-index: -10;
+    overflow-x: hidden;
+    max-width: 495px;
+    max-height: 7em;
+    overflow-y: hidden;
     border: none;
+    padding: 4px 10px 0 10px;
+    color: #888;
+}
+.pretext-content .example-like .aside-like {
+    margin-top: 0;
+    position: absolute;
+}
+.pretext-content .aside-like {
+    font-size: 90%;
+}
+.pretext-content .aside-like {
+  margin-bottom: 5px;
+  background-color: #f5faff;
+  box-shadow: 0 0 1.0em 0.2em #fff inset;
+}
+.pretext-content .aside-like:first-child {
+    margin-top: -2.25em;
+}
+.pretext-content .aside-like:after {
+  content  : "";
+  position : absolute;
+  z-index  : 1;
+  top   : 0em;  
+  bottom   : 0;
+  left     : 0;
+  pointer-events   : none;
+  background-image : linear-gradient(to bottom, 
+                    rgba(255,255,255, 0.4), 
+                    rgba(255,255,255, 1) 90%);
+  width    : 550px;
+  height   : 8em;
+}
+/* example of where the following is needed? */
+/*
+.pretext-content .aside-like * {
+    background-color: #f5faff !important;
+}
+*/
+.pretext-content .aside-like.front, .pretext-content .example-like .aside-like.front {
+  position: relative;
+  z-index: 0;
+  padding: 8px 15px 10px 15px;
+  padding: 2px 10px;
+  margin: 5px 0px 5px 10px;
+  border: 2px solid #dcebfa;
+  max-height: none;
+  max-width: 550px;
+  color: inherit;
+  font-size: 100%;
+  box-shadow: none;
+}
+.pretext-content .aside-like.front:after, .pretext-content .example-like .aside-like.front:after {
+    background-image: none;
+}
+.pretext-content .example-like .aside-like.front {
+    margin-top: 1.25em;
+}
+
+.pretext-content .aside-like.front + p{
+    margin-top: 1.25em !important;
+    padding-top: 0;
 }
 
 
-.pretext-content section article.example-like > .heading {
-    display: inline-block;
-    padding: 0.3em 0.5em;
-    margin-left: -0.8em;
+
+.pretext-content .aside-like .aside-like {
+  background-color: #fafff5;
+  border: 1px dotted #aaa;
 }
 
-
-.pretext-content section article.example-like.example > .heading {
-  border: 0.1em solid var(--exampledark);   /* maybe no border-left? */
+.pretext-content article.aside-like > p:first-child {
+    margin-top: 0;
 }
 
-
-.pretext-content section article.example-like > .heading {
-  background: var(--example);
-  color: black;
+.pretext-content .aside-like > .heading {
+    font-size: 95%;
 }
 
-.pretext-content section article.example-like.example > .heading {
-  background: var(--exampledark);
-  color: #fff;
+.pretext-content .aside-like + *{
+    margin-top: 3em !important;
+    margin-right: 3em;
 }
 
+/* on sufficiently large screens, there is enough of a margin to see part of the aside */
 
-.pretext-content section article.example-like > .heading::after,
-.pretext-content section article.project-like.project > .heading::after,
-.pretext-content section article.project-like.activity > .heading::after,
-.pretext-content section article.project-like.exploration > .heading::after {
-    content: "";
+@media screen and (min-width: 943px) {
+  .pretext-content .aside-like + * {
+      margin-right: 0;
+  }
 }
 
-.pretext-content section article.example-like > .heading + p,
-.pretext-content section article.example-like > .heading + .introduction {
-    display: block;
-    padding-top: 0.3em;
+/* on a wide screen, asides should appear in the right margin */
+@media screen and (min-width: 1100px) {
+  .pretext-content .aside-like, .pretext-content .aside-like.front, .pretext-content .example-like .aside-like, .pretext-content .example-like .aside-like.front {
+      position: absolute;
+      margin-top: -2em;
+      margin-left: 660px;
+      max-width: 200px;  /* for some reason the width was too small, so I had to put width (next line) */
+      width: 200px;
+      color: inherit;
+  }
+  .pretext-content .aside-like.front, .pretext-content .example-like .aside-like.front {
+      max-height: none;
+      max-width: 223px;
+      border: 2px solid #dcebfa;
+}
+  .pretext-content .example-like .aside-like, .pretext-content .example-like .aside-like.front {
+      margin-left: 654px;  /* because .example-like has 6px of padding */
+  }
+
+  .pretext-content .aside-like + * {
+      margin-top: 1.25em !important;
+  /*    background: none;  */
+      margin-right: 0;
+  }
+
+  .pretext-content .aside-like.front:after, .pretext-content .example-like .aside-like.front:after {
+    background-image: none;
+  }
+
+  .pretext-content .aside-like:nth-of-type(3n+1) {
+    margin-left: 660px;
+}
+  .pretext-content .aside-like:nth-of-type(3n) {
+    margin-left: 680px;
+}
+  .pretext-content .aside-like:nth-of-type(3n+2) {
+    margin-left: 640px;
+}
 }
 
-/* remark-like notes get a dotted Greg's L */
-.pretext-content .remark-like.note {
-    padding-left: 0.5em;
-    border-left: 1px dotted #569;
-}
-.pretext-content .remark-like.note::after {
-    content:'';
-    border-bottom: 1px dotted #569;
-    display: block;
-    margin-right: auto;
-    margin-left: -0.5em;
-    padding-top: 0.25em;
-    width: 1.5em;
-}
-/* theorem-like claims get a slightly wide solid Greg's L in the subtitle color */
-.pretext-content .theorem-like.claim {
-    padding-left: 0.5em;
-    border-left: 2px solid var(--bodysubtitle);
-}
-.pretext-content .theorem-like.claim::after {
-    content:'';
-    border-bottom: 2px solid var(--bodysubtitle);
-    display: block;
-    margin-right: auto;
-    margin-left: -0.5em;
-    padding-top: 0.25em;
-    width: 1.5em;
+.pretext-content .aside-like:hover:after, .pretext-content .aside-like:focus:after {
+    top: 3em;
+    height: auto;
+    background-image : none;
 }
 
-.pretext-content section > .proof {
-    margin-bottom: 1em;
+.pretext-content .aside-like:hover, .pretext-content .aside-like:focus {
+    color: inherit;
+    padding: 2px 8px 0 8px;
+    border: 2px solid #dcebfa;
+    height: auto;
+    max-height: none;
+}
+.pretext-content .aside-like.front:hover, .pretext-content .aside-like.front:focus {
+    padding: 4px 10px;
 }
 
+/* find a better way to handle asides in content that has a wide left margin */
+/* see http://pretext.jahrme.com/aside-in-knowl/section-1.html */
+.pretext-content section dl dd .aside-like {
+    margin-top: 0 !important;
+    margin-left: 100px !important;
+}
+.pretext-content section dl dd .aside-like.front {
+    margin-left: -300px !important;
+}
 
-/* where does this appear? */
-/* .posterior {
-  margin-left: 1ex;
-  padding-left: 1ex;
-  margin-top: -1.25em;
-  padding-top: 1ex;
-  border-left: solid 1pt gray;
-} */
-
+@media screen and (max-width: 1099px) {
+  .pretext-content aside.aside-like {
+    position: relative;
+    float: right;
+    z-index: 0;
+    overflow-x: hidden;
+    margin-left: 1em;
+    margin-top: 1em;
+    max-width: 195px;
+    max-height: 4em;
+    margin-right: -8em;
+}
+  .pretext-content li > aside.aside-like:last-child {
+    position: absolute;
+}
+}

--- a/style_oscarlevin.css
+++ b/style_oscarlevin.css
@@ -21,8 +21,8 @@
   --highlighttoctext: white;
   --highlighttocborder: white;
 
-  --assemblageborder: #bfd5ec;
-  --assemblagebackground: #e9eff5;
+  --assembborder: #bfd5ec;
+  --assembbackground: #e9eff5;
 
   --knowlborder: #e0e9ff;
   --knowlbackground: #f5f8ff;
@@ -33,45 +33,27 @@
 
 :root {
 /* Set colors for blocks */
-  --step: 30;
-
-  --hue1: 180;
-  --hue2: calc(var(--hue1) + var(--step));
-  --hue3: calc(var(--hue2) + var(--step));
-  --hue4: calc(var(--hue3) + var(--step));
-  --hue5: calc(var(--hue4) + var(--step));
-
-  --hueassemblage: var(--hue2);
-  --huetheorem: var(--hue4);
-  --huedefinition: var(--hue1);
-  --hueexample: var(--hue3);
-  --hueproject: var(--hue1);
-
-  --sat: 40%;
-  --llight: 94%;
-  --lmid: 75%;
-  --ldark: 25%;
   
-  --assemblagebackground: hsl(var(--hueassemblage), var(--sat), var(--llight));
-  --assemblageborder: hsl(var(--hueassemblage), var(--sat), var(--lmid));
-  --assemblagedarkborder: hsl(var(--hueassemblage), var(--sat), var(--ldark));
-  --definitionbackground: hsl(var(--huedefinition), var(--sat), var(--llight));
-  --definitionborder: hsl(var(--huedefinition), var(--sat), var(--lmid));
-  --definitiondarkborder: hsl(var(--huedefinition), var(--sat), var(--ldark));
-  --theorembackground: hsl(var(--huetheorem), var(--sat), var(--llight));
-  --theoremborder: hsl(var(--huetheorem), var(--sat), var(--lmid));
-  --theoremdarkborder: hsl(var(--huetheorem), var(--sat), var(--ldark));
-  --examplebackground: hsl(var(--hueexample), var(--sat), var(--llight));
-  --exampleborder: hsl(var(--hueexample), var(--sat), var(--lmid));
-  --exampledarkborder: hsl(var(--hueexample), var(--sat), var(--ldark));
-  --projectbackground: hsl(var(--hueproject), var(--sat), var(--llight));
-  --projectborder: hsl(var(--hueproject), var(--sat), var(--lmid));
-  --projectdarkborder: hsl(var(--hueproject), var(--sat), var(--ldark));
+  --assembbackground: var(--infolight, hsl(210, 40%, 94%));
+  --assembborder: var(--info, hsl(210, 40%, 75%));
+  --assembheading: var(--infodark, hsl(210, 40%, 25%));
+  --definitionbackground: var(--secondarylight, hsl(180, 40%, 94%));
+  --definitionborder: var(--secondarydull, hsl(180, 40%, 75%));
+  --definitiondarkborder: var(--secondaryrich, hsl(180, 40%, 25%));
+  --theorembackground: var(--primarylight, hsl(270, 40%, 94%));
+  --theoremborder: var(--primary, hsl(270, 40%, 75%));
+  --theoremdarkborder: var(--primarydark, hsl(270, 40%, 25%));
+  --examplebackground: var(--primarylight, hsl(240, 40%, 94%));
+  --example: var(--primary, hsl(240, 40%, 75%));
+  --exampledark: var(--primarydark, hsl(240, 40%, 25%));
+  --projectbackground: var(--primarylight, hsl(180, 40%, 94%));
+  --projectborder: var(--primary, hsl(180, 40%, 75%));
+  --investigateborder: var(--primaryrich, hsl(180, 40%, 25%));
 
-  --knowlborder: var(--bodytitlehighlight);
+  /* --knowlborder: var(--bodytitlehighlight);
   --knowlborder: white;
-  --knowlbackground: var(--assemblagebackground);
-  --knowlbackground: white;
+  --knowlbackground: var(--assembbackground);
+  --knowlbackground: white; */
 }
 
 /* Remove Greg-L on assemblage and everything else */
@@ -92,8 +74,8 @@
 
 /* backgrounds and borders: */
 .pretext-content .assemblage-like{
-    background-color: var(--assemblagebackground);
-    border: 2px solid var(--assemblageborder);
+    background-color: var(--assembbackground);
+    border: 2px solid var(--assembborder);
 }
 
 .pretext-content .theorem-like {
@@ -137,8 +119,8 @@
 }
 
 .pretext-content .assemblage-like .heading {
-  background-color: var(--assemblageborder);
-  color: #fff;
+  background-color: var(--assembborder);
+  color: #000;
 }
 
 .pretext-content .definition-like .heading {
@@ -155,7 +137,7 @@
     border: 2px solid var(--bodysubtitle);
 }
 .pretext-content .theorem-like.principle .heading {
-    background-color: var(--assemblageborder);
+    background-color: var(--assembborder);
 } */
 
 .pretext-content .assemblage-like .heading::after,
@@ -169,6 +151,7 @@
     display: block;
 }
 
+/* These gradients need to be adjusted to match background colors */
 .pretext-content .assemblage-like .MJXc-display,
 .pretext-content .definition-like .MJXc-display,
 .pretext-content .theorem-like.theorem .MJXc-display {
@@ -221,7 +204,7 @@
 }
 
 .pretext-content section article.project-like.investigation {
-  border-color: var(--projectdarkborder);
+  border-color: var(--investigateborder);
 }
 
 .pretext-content section article.project-like > .heading {
@@ -261,17 +244,17 @@
 
 
 .pretext-content section article.example-like.example > .heading {
-  border: 0.1em solid var(--exampledarkborder);   /* maybe no border-left? */
+  border: 0.1em solid var(--exampledark);   /* maybe no border-left? */
 }
 
 
 .pretext-content section article.example-like > .heading {
-  background: var(--exampleborder);
+  background: var(--example);
   color: black;
 }
 
 .pretext-content section article.example-like.example > .heading {
-  background: var(--exampledarkborder);
+  background: var(--exampledark);
   color: #fff;
 }
 


### PR DESCRIPTION
The changes here are mostly under-the-hood, and with a few minor exceptions, nobody should notice anything change.  The exceptions are: if someone uses style_oscarlevin, then a few more environments will get styled; if additionally they are using the colors_blue_green, the colors of the environments styled by style_oscarlevin will be different.

style_oscarlevin.css has been updated to ensure that all *-like environments get some styling, and the organization of the css is improved.

This pull request also includes a potential solution to having colors be more consistent with color_*_*.css files.  The proposal is for the color_*.*.css to specify some standard color classes that work harmoniously with the colors already specified, and then that style_*.css files can import these if they are available, or fall back to their standard "defaults".

You can see what happens by building with or without the colors_blue_green.css.