### PR TITLE
Navbar z fix

### DIFF
--- a/navbar_default.css
+++ b/navbar_default.css
@@ -10,7 +10,7 @@ nav.ptx-navbar {
   background: #ededed;
   border-bottom: 1px solid #bababa;
   margin: 0;
-  z-index: 20;
+  z-index: 100;
   min-height: unset;  /* to combat navbar.less */
 /*
   height: 35.36px;

--- a/pretext_add_on.css
+++ b/pretext_add_on.css
@@ -1984,6 +1984,41 @@ from Jiří Lebl */
     width: 3.0em;
 }
 
+.ptx-content pre[data-line].program, 
+.ptx-content pre[data-line].code-block
+{
+    padding-left: 2.5em;
+}
+
+.ptx-content pre[data-line].program:before,
+.ptx-content pre[data-line].code-block:before {
+    margin-left: -5em;
+}
+
+.ptx-content pre.program.line-numbers,
+.ptx-content pre.code-block.line-numbers
+{
+    padding-left: 3.5em;
+    overflow: visible;
+}
+
+.ptx-content pre.program.line-numbers:before,
+.ptx-content pre.code-block.line-numbers:before {
+    margin-left: -7em;
+}
+
+/* fine tune next 3 based on line-height of surrounding pre  */
+.ptx-content pre[data-line].line-numbers code {
+    padding-top: 0em;  /* increase with line-height */
+}
+.ptx-content pre[data-line].line-numbers .line-highlight {
+    margin-top: 0em; /* decreases as line-height increases */
+}
+.ptx-content pre[data-line]:not(.line-numbers) .line-highlight {
+    margin-top: 0.6em; /* decreases as line-height increases */
+}
+
+
 /* next is for the old code formatting js */
 .ptx-content pre.prettyprint,
 .ptx-content pre.plainprint {


### PR DESCRIPTION
Runestone's Codelens features UI elements with inline z-index of 90. These cover up the PreTeXt navbar as seen in picture below (Look at Prev button). This just moves navbar up to 100.

![image](https://github.com/PreTeXtBook/CSS_core/assets/7787413/db18df03-9ec8-409b-b83d-50e1917b7587)
