### PR TITLE
Remove pre background color overrides

### DIFF
--- a/pretext.css
+++ b/pretext.css
@@ -177,7 +177,6 @@ so that we can set our own later */
 }
 /* these are to over-ride "pre" styling in code.less */
 .ptx-content pre {
-    background: inherit;
     border-radius: 0;
 }
 

--- a/pretext_add_on.css
+++ b/pretext_add_on.css
@@ -1971,7 +1971,6 @@ from Jiří Lebl */
     border-left: 1px solid #aaa;
     font-size: 93%;
     overflow: auto;
-    background: inherit;  /* over-ride Prism's #f5f2f0 */
 }
 .ptx-content pre.program:before,
 .ptx-content pre.code-block:before {


### PR DESCRIPTION
These have the effect of making the background of code areas transparent. That doesn't work in situations where pre is on top of a colored background. Also prevents any chance of prism highlighting setting background - I'd like to add support for different prism themes including dark ones.

I think we should trust prism's background to support theming. But if a white background is desired as default, maybe set it in one of the overrideable theme files (style.css?). Once this is changed in pretext and pretext_add_on there is no going back to what prism tried to set.

Example of issues caused by unsetting the background:
![image](https://github.com/PreTeXtBook/CSS_core/assets/7787413/5b05791c-9268-4ad2-930a-1c0969024447)
