### PR TITLE
Changes to mask changes to html in navbar

### DIFF
--- a/navbar_crc.css
+++ b/navbar_crc.css
@@ -20,6 +20,7 @@
   padding-top: unset;
 }
 
+
 /* Generic and large screen layout */
 
 .ptx-navbar .button {
@@ -233,11 +234,27 @@ nav.ptx-navbar::after {
 .ptx-navbar .index-button .name {
     /*  Nada */
 }
+.ptx-navbar .index-button .icon {
+    display: none;
+}
 
 .ptx-navbar .calculator-toggle .name {
     /*  Nada */
 }
+.ptx-navbar .calculator-toggle .icon {
+    display: none;
+}
 
+.ptx-navbar .runestone-profile .name {
+    display: none;
+}
+
+.ptx-navbar .activecode-toggle .name {
+    display: none;
+}
+
+.ptx-navbar .dropdown {
+    height: 35px;
 
 .ptx-navbar .up-button {
     text-align: center;

--- a/navbar_default.css
+++ b/navbar_default.css
@@ -98,38 +98,24 @@ nav.ptx-navbar {
   bottom: 0.53em;
 }
 
-.ptx-navbar .up-button {
-  text-align: center;
-}
-
 .ptx-navbar .name {
   display: inline-block;
   position: relative;
   bottom: 0;
 }
-.ptx-navbar .treebuttons .name {
-  bottom: 0.2em;
-}
+
 .ptx-navbar .icon {
   display: inline-block;
-  font-size: 1.5em;
+  font-size: 1em;
 }
-.ptx-navbar .previous-button .icon {
-  margin-left: 0.3em;
-  margin-right: 0.2em;
+
+.ptx-navbar .treebuttons > :is(a, span) {
+  display: flex;
+  gap: 0.2em;
+  align-items: center;
+  justify-content: center;
 }
-.ptx-navbar .up-button .icon {
-  margin-left: 00;
-  margin-right: 0.2em;
-  padding-top: 2px;
-}
-.ptx-navbar .up-button .name {
-  bottom: 0.3em;
-}
-.ptx-navbar .next-button .icon {
-  margin-left: 0.2em;
-  margin-right: 0.3em;
-}
+
 .ptx-navbar .index-button .name {
   padding-top: 0.3em;
 }
@@ -138,6 +124,22 @@ nav.ptx-navbar {
 }
 .ptx-navbar .avatarbutton {
   font-size: 1.0em;
+}
+
+.ptx-navbar .index-button .icon {
+  display: none;
+}
+.ptx-navbar .calculator-toggle .icon {
+  display: none;
+}
+.ptx-navbar .runestone-profile .name {
+  display: none;
+}
+.ptx-navbar .activecode-toggle .name {
+  display: none;
+}
+.ptx-navbar .searchbutton .name {
+  display: none;
 }
 
 @media screen and (max-width: 800px) {

--- a/pretext_search.css
+++ b/pretext_search.css
@@ -24,6 +24,10 @@
   right: 0;
 }
 
+.searchbutton .name {
+  display: none;
+}
+
 .searchwidget {
 /*
     padding-top: 15px;

--- a/shell_default.css
+++ b/shell_default.css
@@ -150,17 +150,30 @@
   display: flex;
   flex-direction: row;
   justify-content: space-around;
-  max-width: 650px;
+  max-width: 600px;
+  margin-left: 32px;
 }
 .pretext .ptx-content-footer .button {
   cursor: pointer;
   text-align: center;
+  width: 65px;
+  height: 35px;
   color: #333333;
   background-color: #ededed;
   border: 1px solid #bababa;
   padding: 0;
+  margin-top: 0.5em;
   display: flex;
   align-items: center;
+  display: flex;
+  gap: 0.2em;
+  align-items: center;
+  justify-content: center;
+  /* Disable accidental text-selection */
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .pretext .ptx-content-footer .button:hover,
 .pretext .ptx-content-footer .button:active,
@@ -168,84 +181,6 @@
   background-color: #fafafa;
 }
 
-.pretext .ptx-content-footer .button.top-button {
-  text-align: center;
-  width: 40px;
-  height: 50px;
-}
-.pretext .ptx-content-footer .button.previous-button,
-.pretext .ptx-content-footer .button.next-button {
-  font-size: 1.0em;
-  cursor: pointer;
-  display: inline-block;
-  vertical-align: middle;
-  height: 35px;
-  width: 65px;
-  /* Disable accidental text-selection */
-  user-select: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  float: left;
-  position: relative;
-  margin-top: 0.5em;
-}
-.pretext .ptx-content-footer .previous-button {
-  text-align: left;
-}
-.pretext .ptx-content-footer .next-button {
-  text-align: right;
-}
-
-.pretext .ptx-content-footer .name {
-  position: relative;
-  bottom: 0;
-}
-.pretext .ptx-content-footer .icon {
-  font-size: 1.3em;
-  Position: relative;
-  bottom: -0.1em;
-}
-.pretext .ptx-content-footer .previous-button .icon {
-  margin-left: 0.3em;
-  margin-right: 0.2em;
-}
-.pretext .ptx-content-footer .next-button .icon {
-  margin-left: 0.2em;
-  margin-right: 0.3em;
-}
-.pretext .ptx-content-footer .next-button {
-  text-align: right;
-}
-.pretext .ptx-content-footer .previous-button {
-    width: 70px;
-    float: right;
-    border-left: 1px solid #bababa;
-    border-right: 1px solid #bababa;
-}
-.pretext .ptx-content-footer .next-button {
-    width: 70px;
-    float: right;
-    border-right: 1px solid #bababa;
-}
-
-
-
-.pretext .ptx-content-footer .top-button {
-  display: block;
-}
-
-.pretext .ptx-content-footer .top-button .icon,
-.pretext .ptx-content-footer .top-button .name {
-  display: block;
-}
-.pretext .ptx-content-footer .top-button .icon {
-  bottom: 0;
-}
-.pretext .ptx-content-footer .top-button .name {
-  position: relative;
-  bottom: 0.4em;
-}
 
 .pretext .ptx-sidebar.visible {
   display: block;


### PR DESCRIPTION
This is to mask changes in https://github.com/PreTeXtBook/pretext/pull/2048 so that default and crc themes. Don't visually change. Safe to deploy before PreTeXt PR - should have no adverse effects in absence of it.

Also, simplifies css for next/prev/up/top buttons in default theme.
